### PR TITLE
Fix Tainted Ampharos' Costumes

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+-v1.8.2-
+*Fixed a bug where Tainted Ampharos' horn and tail costumes would not be applied
+
 -v1.8.1-
 *Tainted Ampharos has received additional stat changes
     *Tainted Ampharos has slightly reduced attack, slightly increased fire rate, and decreased luck

--- a/luaAITB/characters/sheepCosts.lua
+++ b/luaAITB/characters/sheepCosts.lua
@@ -5,7 +5,7 @@ sheepCosts = {}
 
 local costumes = {
     pure = {"ampharosbody", "amphhorn"},
-    tainted = {"ampharosaltbody", "amphalthorn"}
+    tainted = {"ampharosbodyalt", "amphhornalt"}
 }
 
 local function getCosts(player)


### PR DESCRIPTION
Due to a typo, Tainted Ampharos' horn and tail costumes would not be applied. This PR resolves it.
Considering Thunder will likely take a bit of time, I wanted to iron out existing issues before starting work on it.